### PR TITLE
 Fixed the cluster not spinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 terraform/*.tfstate
 terraform/*.tfstate.*
 
+#tf vars file
+aws/terraform-aws/gz.auto.tfvars
+
 # Crash log files
 terraform/crash.log
 
@@ -36,3 +39,7 @@ terraform/*_override.tf.json
 **/k8s/monitoring/alertmanager.yaml
 **/k8s/monitoring/monitoring-secrets.yaml
 **/k8s/staging/staging-secrets.yaml
+
+
+
+

--- a/aws/terraform-aws/eks-cluster.tf
+++ b/aws/terraform-aws/eks-cluster.tf
@@ -15,6 +15,7 @@ terraform {
 
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
+  version         = "17.24.0"
   cluster_name    = local.cluster_name
   cluster_version = "1.21"
   map_users       = var.map_users


### PR DESCRIPTION
The version needs to be added to the aws-eks- module.

Also need to delete the auth module in state file before spinning up the cluster.
terraform state rm module.eks.kubernetes_config_map.aws_auth

refernce link: https://lifesaver.codes/answer/error-post-http-localhost-api-v1-namespaces-kube-system-configmaps-dial-tcp-127-0-0-1-80-connect-connection-refused-911