### PR TITLE
Push terraform infra images to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,12 @@ jobs:
                 circleci-agent step halt
             else            
                 TAG="0.1.${CIRCLE_BUILD_NUM}"
-                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile .
-                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile .
+                docker build -t geekzone/aws-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/aws-infra/Dockerfile .
+                docker build -t geekzone/azure-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/azure-infra/Dockerfile .
                 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
                 docker push geekzone/aws-infra:$TAG
                 docker push geekzone/azure-infra:$TAG
             fi
-    working_directory: ~/project
   
 
   terraform-cycle:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             TF_FILES=$(curl -s -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/GeekZoneHQ/infra/pulls/17/files | jq '.[] | {filename} | values[]' | grep .tf | wc -l)
             echo "The number of modified or added terraform files in this PR is $TF_FILES"
 
-            if [ "$TF_FILES" -eq 0 ]
+            if [ "$TF_FILES" -gt 0 ]
             then
                 circleci-agent step halt
             else            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,35 @@ version: 2.1
 orbs:
   terraform: circleci/terraform@3.0.1
 jobs:
+  build-publish:
+    docker:
+      - image: 'cimg/base:stable'
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.7       
+      - run:
+          name: Build and push terraform infra images to repository
+          command: |
+            TF_FILES=$(curl -s -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/GeekZoneHQ/infra/pulls/17/files | jq '.[] | {filename} | values[]' | grep .tf | wc -l)
+            echo "The number of modified or added terraform files in this PR is $TF_FILES"
+            TOTAL_FILES=$(curl -s -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/GeekZoneHQ/infra/pulls/17/files | jq '.[] | {filename} | values[]' | wc -l)
+            echo "The total number of modified or added files in this PR is $TOTAL_FILES"
+
+            if [ "$TF_FILES" -eq "$TOTAL_FILES" ]; then
+                circleci-agent step halt
+            else            
+                TAG="0.1.${CIRCLE_BUILD_NUM}"
+                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile .
+                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile .
+                docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+                docker push geekzone/aws-infra:$TAG
+                docker push geekzone/azure-infra:$TAG
+            fi
+
   terraform-cycle:
     executor: terraform/default
     steps:
@@ -18,17 +47,24 @@ jobs:
             terraform init
             terraform validate
             terraform plan
-      #       terraform apply -auto-approve
-      # - run:
-      #     name: Destroy infrastructure
-      #       terraform destroy -auto-approve
-      #     command: terraform destroy -auto-approve
-             
+            cd ../../azure/terraform-azure
+            terraform init
+            terraform validate
+            terraform plan
     working_directory: ~/src
+
+    
 workflows:
   main-infra:
     jobs:
+      - build-publish:
+          filters:
+            branches:
+              ignore: 
+              - /junk-.*/
       - terraform-cycle:
+          requires:
+          - build-publish
           filters:
             branches:
               ignore: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,21 +11,19 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.7       
+          version: 20.10.7     
       - run:
           name: Build and push terraform infra images to repository
           command: |
             TF_FILES=$(curl -s -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/GeekZoneHQ/infra/pulls/17/files | jq '.[] | {filename} | values[]' | grep .tf | wc -l)
             echo "The number of modified or added terraform files in this PR is $TF_FILES"
-            TOTAL_FILES=$(curl -s -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/GeekZoneHQ/infra/pulls/17/files | jq '.[] | {filename} | values[]' | wc -l)
-            echo "The total number of modified or added files in this PR is $TOTAL_FILES"
 
-            if [ "$TF_FILES" -eq "$TOTAL_FILES" ]; then
+            if [ "$TF_FILES" -eq 0 ]; then
                 circleci-agent step halt
             else            
                 TAG="0.1.${CIRCLE_BUILD_NUM}"
-                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile .
-                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile .
+                docker build -t geekzone/aws-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/aws-infra/Dockerfile .
+                docker build -t geekzone/azure-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/azure-infra/Dockerfile .
                 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
                 docker push geekzone/aws-infra:$TAG
                 docker push geekzone/azure-infra:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
                 circleci-agent step halt
             else            
                 TAG="0.1.${CIRCLE_BUILD_NUM}"
-                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile .
-                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile .
+                docker build -t geekzone/aws-infra:$TAG -f project/docker/aws-infra/Dockerfile .
+                docker build -t geekzone/azure-infra:$TAG -f project/docker/azure-infra/Dockerfile .
                 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
                 docker push geekzone/aws-infra:$TAG
                 docker push geekzone/azure-infra:$TAG
@@ -69,3 +69,4 @@ workflows:
             branches:
               ignore: 
               - /junk-.*/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
                 circleci-agent step halt
             else            
                 TAG="0.1.${CIRCLE_BUILD_NUM}"
-                docker build -t geekzone/aws-infra:$TAG -f project/docker/aws-infra/Dockerfile .
-                docker build -t geekzone/azure-infra:$TAG -f project/docker/azure-infra/Dockerfile .
+                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile /home/circleci/project
+                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile /home/circleci/project
                 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
                 docker push geekzone/aws-infra:$TAG
                 docker push geekzone/azure-infra:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
                 circleci-agent step halt
             else            
                 TAG="0.1.${CIRCLE_BUILD_NUM}"
-                docker build -t geekzone/aws-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/aws-infra/Dockerfile .
-                docker build -t geekzone/azure-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/azure-infra/Dockerfile .
+                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile .
+                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile .
                 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
                 docker push geekzone/aws-infra:$TAG
                 docker push geekzone/azure-infra:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
                 docker push geekzone/aws-infra:$TAG
                 docker push geekzone/azure-infra:$TAG
             fi
+    working_directory: ~/project
+  
 
   terraform-cycle:
     executor: terraform/default
@@ -53,7 +55,7 @@ jobs:
             terraform plan
     working_directory: ~/src
 
-    
+
 workflows:
   main-infra:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,13 @@ jobs:
             TF_FILES=$(curl -s -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/GeekZoneHQ/infra/pulls/17/files | jq '.[] | {filename} | values[]' | grep .tf | wc -l)
             echo "The number of modified or added terraform files in this PR is $TF_FILES"
 
-            if [ "$TF_FILES" -eq 0 ]; then
+            if [ "$TF_FILES" -eq 0 ]
+            then
                 circleci-agent step halt
             else            
                 TAG="0.1.${CIRCLE_BUILD_NUM}"
-                docker build -t geekzone/aws-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/aws-infra/Dockerfile .
-                docker build -t geekzone/azure-infra:$TAG -f ${CIRCLE_WORKING_DIRECTORY}/docker/azure-infra/Dockerfile .
+                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile .
+                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile .
                 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
                 docker push geekzone/aws-infra:$TAG
                 docker push geekzone/azure-infra:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,25 +11,31 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.7     
+          version: 20.10.7    
       - run:
-          name: Build and push terraform infra images to repository
+          name: Build terraform aws-infra image 
+          background: true
           command: |
-            TF_FILES=$(curl -s -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/GeekZoneHQ/infra/pulls/17/files | jq '.[] | {filename} | values[]' | grep .tf | wc -l)
-            echo "The number of modified or added terraform files in this PR is $TF_FILES"
-
-            if [ "$TF_FILES" -gt 0 ]
-            then
-                circleci-agent step halt
-            else            
-                TAG="0.1.${CIRCLE_BUILD_NUM}"
-                docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile /home/circleci/project
-                docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile /home/circleci/project
-                docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-                docker push geekzone/aws-infra:$TAG
-                docker push geekzone/azure-infra:$TAG
-            fi
-  
+            TAG="0.1.${CIRCLE_BUILD_NUM}"
+            docker build -t geekzone/aws-infra:$TAG -f docker/aws-infra/Dockerfile .  
+      - run:
+          name: Build terraform azure-infra image 
+          command: |
+            TAG="0.1.${CIRCLE_BUILD_NUM}"
+            docker build -t geekzone/azure-infra:$TAG -f docker/azure-infra/Dockerfile .         
+      - deploy:
+          name: Push aws-infra image to Docker Hub
+          background: true
+          command: |
+            TAG="0.1.${CIRCLE_BUILD_NUM}"
+            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+            docker push geekzone/aws-infra:$TAG
+      - deploy:
+          name: Push azure-infra image to Docker Hub
+          command: |
+            TAG="0.1.${CIRCLE_BUILD_NUM}"
+            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+            docker push geekzone/azure-infra:$TAG
 
   terraform-cycle:
     executor: terraform/default

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  target-branch: master
+  target-branch: main
   reviewers:
     - "jamesgeddes"
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,6 @@
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] I have read the **[CONTRIBUTING](https://github.com/GeekZoneHQ/web/blob/master/CONTRIBUTING.md)** document.
+- [ ] I have read the **[CONTRIBUTING](https://github.com/GeekZoneHQ/web/blob/main/CONTRIBUTING.md)** document.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -47,6 +47,6 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISABLE_ERRORS: true

--- a/docker/aws-infra/Dockerfile
+++ b/docker/aws-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform aws/terraform-aws/ .
+COPY --chown=terraform:terraform project/aws/terraform-aws/ .
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/aws-infra/Dockerfile
+++ b/docker/aws-infra/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine
+
+RUN apk update && \
+    apk add terraform
+
+WORKDIR /usr/src/terraform
+
+RUN adduser -D terraform
+    
+COPY --chown=terraform:terraform aws/terraform-aws/ . 
+
+RUN chmod -R 755 /usr/src/terraform/
+
+USER terraform

--- a/docker/aws-infra/Dockerfile
+++ b/docker/aws-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform /home/circleci/project/aws/terraform-aws/ .
+COPY --chown=terraform:terraform aws/terraform-aws/ .
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/aws-infra/Dockerfile
+++ b/docker/aws-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform project/aws/terraform-aws/ .
+COPY --chown=terraform:terraform ./aws/terraform-aws/ .
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/aws-infra/Dockerfile
+++ b/docker/aws-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform aws/terraform-aws/ . 
+COPY --chown=terraform:terraform /home/circleci/project/aws/terraform-aws/ .
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/azure-infra/Dockerfile
+++ b/docker/azure-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform azure/terraform-azure/ . 
+COPY --chown=terraform:terraform project/azure/terraform-azure/ . 
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/azure-infra/Dockerfile
+++ b/docker/azure-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform project/azure/terraform-azure/ . 
+COPY --chown=terraform:terraform ./azure/terraform-azure/ . 
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/azure-infra/Dockerfile
+++ b/docker/azure-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform /home/circleci/project/azure/terraform-azure/ . 
+COPY --chown=terraform:terraform azure/terraform-azure/ . 
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/azure-infra/Dockerfile
+++ b/docker/azure-infra/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/terraform
 
 RUN adduser -D terraform
     
-COPY --chown=terraform:terraform azure/terraform-azure/ . 
+COPY --chown=terraform:terraform /home/circleci/project/azure/terraform-azure/ . 
 
 RUN chmod -R 755 /usr/src/terraform/
 

--- a/docker/azure-infra/Dockerfile
+++ b/docker/azure-infra/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine
+
+RUN apk update && \
+    apk add terraform
+
+WORKDIR /usr/src/terraform
+
+RUN adduser -D terraform
+    
+COPY --chown=terraform:terraform azure/terraform-azure/ . 
+
+RUN chmod -R 755 /usr/src/terraform/
+
+USER terraform


### PR DESCRIPTION
Currently we do not have images for terraform infra. They may be useful to run apply and destroy Terraform cycles from a k8s cluster, in order to plan infrastructure destruction at a specific schedule.

## Related Issue
"resolves #20" 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/GeekZoneHQ/web/blob/main/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
